### PR TITLE
Use absolute URLs for Open Graph images

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="404 - Page Not Found | Top Tier Electrical">
   <meta property="og:description" content="The page you requested cannot be found. Browse our services or get in touch for assistance.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/404.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/404.html">

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="About | Top Tier Electrical">
   <meta property="og:description" content="Discover who we are, our qualifications and why West Michigan trusts Top Tier Electrical.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/about.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/about.html">

--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Contact | Top Tier Electrical">
   <meta property="og:description" content="We’re here to help with all your electrical needs—reach out by phone, email or contact form for a prompt response.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/contact.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/contact.html">

--- a/emergency.html
+++ b/emergency.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Emergency Electrical Services | Top Tier Electrical">
   <meta property="og:description" content="Learn what to do in an electrical emergency and call our 24/7 emergency hotline for immediate assistance.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/emergency.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/emergency.html">

--- a/faq.html
+++ b/faq.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Frequently Asked Questions | Top Tier Electrical">
   <meta property="og:description" content="Find answers to common questions about our electrical services in West Michigan.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/faq.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/faq.html">

--- a/financing.html
+++ b/financing.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Financing | Top Tier Electrical">
   <meta property="og:description" content="Learn about our financing partners and how you can spread the cost of your next electrical upgrade.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/financing.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/financing.html">

--- a/gallery.html
+++ b/gallery.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Gallery | Top Tier Electrical">
   <meta property="og:description" content="Explore photos of our electrical projects—from panel upgrades and conduit installations to LED lighting solutions.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/gallery.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/gallery.html">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Top Tier Electrical | Trusted Electrician in West Michigan">
   <meta property="og:description" content="Providing dependable electrical solutions for homes and businesses across West Michigan.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/">

--- a/services.html
+++ b/services.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Services | Top Tier Electrical">
   <meta property="og:description" content="Discover our residential and commercial electrical services: panel upgrades, EV chargers, lighting & fixtures.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/services.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/services.html">

--- a/testimonials.html
+++ b/testimonials.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Testimonials | Top Tier Electrical">
   <meta property="og:description" content="See what our customers have to say about our electrical services and workmanship.">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/images/hero.jpg">
+  <meta property="og:image" content="https://www.toptier-electrical.com/assets/images/hero.jpg">
   <meta property="og:url" content="https://www.toptier-electrical.com/testimonials.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.toptier-electrical.com/testimonials.html">


### PR DESCRIPTION
## Summary
- Convert Open Graph image meta tags in all HTML pages to use the production domain with absolute paths.
- Ensure existing `og:url` and canonical links continue to reference the production domain.

## Testing
- `npx --yes htmlhint "*.html"`
- `curl -I https://www.toptier-electrical.com/assets/images/hero.jpg` *(returns 404, verify after deployment)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a62356508331aa46108d76d6de66