### PR TITLE
Add lazy loading and dimensions to gallery images

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -53,16 +53,16 @@
         <h2>Project Showcase</h2>
         <div class="gallery-grid">
           <!-- Use your repo paths for images -->
-          <img src="/images/gallery/3-phase-service.jpg" alt="3‑Phase Service Panel">
-          <img src="/images/gallery/conduit-piping.jpg" alt="Conduit Piping">
-          <img src="/images/gallery/control-cabinet.jpg" alt="Control Cabinet">
-          <img src="/images/gallery/dust-collector.jpg" alt="Dust Collector System">
-          <img src="/images/gallery/fire-response.jpg" alt="Fire Response Wiring">
-          <img src="/images/gallery/kitchen-led.jpg" alt="Kitchen LED Lighting">
-          <img src="/images/gallery/led-handrail.jpg" alt="LED Handrail Lighting">
-          <img src="/images/gallery/led-shelves.jpg" alt="LED Shelves">
-          <img src="/images/gallery/service-before.jpg" alt="Service Before Upgrade">
-          <img src="/images/gallery/service-after.jpg" alt="Service After Upgrade">
+          <img src="/images/gallery/3-phase-service.jpg" alt="3‑Phase Service Panel" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/conduit-piping.jpg" alt="Conduit Piping" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/control-cabinet.jpg" alt="Control Cabinet" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/dust-collector.jpg" alt="Dust Collector System" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/fire-response.jpg" alt="Fire Response Wiring" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/kitchen-led.jpg" alt="Kitchen LED Lighting" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/led-handrail.jpg" alt="LED Handrail Lighting" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/led-shelves.jpg" alt="LED Shelves" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/service-before.jpg" alt="Service Before Upgrade" loading="lazy" width="800" height="600">
+          <img src="/images/gallery/service-after.jpg" alt="Service After Upgrade" loading="lazy" width="800" height="600">
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` and placeholder dimensions to gallery images for layout stability

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a6212f4c83318a885ddababeeb55